### PR TITLE
Correct date format for JSON Feed

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -23,7 +23,7 @@
             "id": {{ $element.Permalink | jsonify }},
             "url": {{ $element.Permalink | jsonify }},
             "content_html": {{ $element.Content | jsonify }},
-            "date_published": {{ $element.Date.Format "2006-02-01T15:04:05-0700" | jsonify }}
+            "date_published": {{ $element.Date.Format "2006-01-02T15:04:05-0700" | jsonify }}
         }
         {{ end }}
     ]


### PR DESCRIPTION
I snagged your implementation for my blog and noticed it was generating incorrectly formatted dates.

e.g. this example from your current live feed:

```
"date_published": "2017-17-05T10:00:00-0700"
```
And since it's YYYY-MM-DD that's flaking out on no such month '17'.
The date templating stuff is weird.

> Format strings absolutely must adhere to the 1-2-3-4-5-6-7 order:
> Month must be Jan, January, 01, or 1
> Date must be 02 or 2

So the way it was written was trying to generate YYYY-DD-MM.